### PR TITLE
Implemented the caching mechanism to reset the cache value.

### DIFF
--- a/src/main/java/com/intelliguru/simplora/cache/AppCache.java
+++ b/src/main/java/com/intelliguru/simplora/cache/AppCache.java
@@ -16,12 +16,22 @@ public class AppCache {
     @Autowired
     private ConfigRepository configRepository;
 
-    public  final Map<String, String> APP_CACHE = new HashMap<>();
+    private Map<String, String> cacheDataMap;
     @PostConstruct
-    public void init(){
+    public boolean init(){
+        boolean isReset = false;
+        cacheDataMap = new HashMap<>();
         List<ConfigEntity> all = configRepository.findAll();
         for (ConfigEntity configEntity : all){
-            APP_CACHE.put(configEntity.getKey(), configEntity.getValue());
+            cacheDataMap.put(configEntity.getKey(), configEntity.getValue());
         }
+
+        if(!cacheDataMap.isEmpty()){
+            isReset = true;
+        }
+        return isReset;
+    }
+    public String getApiValue(String key){
+        return cacheDataMap.get(key);
     }
 }

--- a/src/main/java/com/intelliguru/simplora/controller/AdminController.java
+++ b/src/main/java/com/intelliguru/simplora/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.intelliguru.simplora.controller;
 
+import com.intelliguru.simplora.cache.AppCache;
 import com.intelliguru.simplora.entity.User;
 import com.intelliguru.simplora.service.UserService;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -12,10 +14,23 @@ import java.util.List;
 
 @RequestMapping("/admin")
 @RestController
+@Slf4j
 public class AdminController {
 
     @Autowired
     private UserService userService;
+    @Autowired
+    private AppCache appCache;
+
+    @GetMapping("clear-cache")
+    public ResponseEntity<?> resetCache(){
+        boolean reset = appCache.init();
+        if(reset){
+            return new ResponseEntity<>("The cache Value has been successfully invalidated.", HttpStatus.OK);
+        }
+        log.error("Some error occurred while invalidating the cache.");
+        throw new RuntimeException("Some error occurred while invalidating the cache.");
+    }
 
     @GetMapping("/all-users")
     public ResponseEntity<?> getAllUsers(){

--- a/src/main/java/com/intelliguru/simplora/controller/UserController.java
+++ b/src/main/java/com/intelliguru/simplora/controller/UserController.java
@@ -1,20 +1,20 @@
 package com.intelliguru.simplora.controller;
 
-import com.intelliguru.simplora.api.response.WeatherResponse;
 import com.intelliguru.simplora.entity.User;
+import com.intelliguru.simplora.exception.WeatherException;
 import com.intelliguru.simplora.repository.UserRepository;
 import com.intelliguru.simplora.service.UserService;
 import com.intelliguru.simplora.service.WeatherService;
 import com.intelliguru.simplora.utils.SecurityContextUtility;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/user")
 @RestController
+@Slf4j
 public class UserController {
     @Autowired
     private UserService userService;
@@ -24,15 +24,16 @@ public class UserController {
     @Autowired
     private WeatherService weatherService;
 
-    @GetMapping
-    public ResponseEntity<?> greeting() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        WeatherResponse weatherResponse = weatherService.getWeather("Mumbai");
-        String greeting = "";
-        if (weatherResponse != null) {
-            greeting = ", Weather feels like " + weatherResponse.getCurrent().getFeelslike();
+    @GetMapping("/{city}")
+    public ResponseEntity<?> greeting(@PathVariable String city) {
+        try {
+            String userName = SecurityContextUtility.getAuthenticatedUser();
+            String weatherResponse = weatherService.getWeather(city, userName);
+            return new ResponseEntity<>(weatherResponse, HttpStatus.OK);
+        } catch (WeatherException e) {
+            log.error(e.getMessage());
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<>("Hi " + authentication.getName() + greeting, HttpStatus.OK);
     }
 
     @PutMapping

--- a/src/main/java/com/intelliguru/simplora/exception/WeatherException.java
+++ b/src/main/java/com/intelliguru/simplora/exception/WeatherException.java
@@ -1,0 +1,7 @@
+package com.intelliguru.simplora.exception;
+
+public class WeatherException extends  Exception{
+    public WeatherException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/intelliguru/simplora/service/WeatherService.java
+++ b/src/main/java/com/intelliguru/simplora/service/WeatherService.java
@@ -2,12 +2,17 @@ package com.intelliguru.simplora.service;
 
 import com.intelliguru.simplora.api.response.WeatherResponse;
 import com.intelliguru.simplora.cache.AppCache;
+import com.intelliguru.simplora.exception.WeatherException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import static com.intelliguru.simplora.utils.constants.Constants.API_KEY;
+import static com.intelliguru.simplora.utils.constants.Constants.CITY;
+import static com.intelliguru.simplora.utils.constants.Keys.WEATHER_API;
 
 @Service
 public class WeatherService {
@@ -20,10 +25,19 @@ public class WeatherService {
     @Autowired
     private AppCache appCache;
 
-    public WeatherResponse getWeather(String city){
-        String weatherApi = appCache.APP_CACHE.get("weather_api").replace("<city>",city)
-                .replace("<api_key>",apiKey);
-        ResponseEntity<WeatherResponse> response = restTemplate.exchange(weatherApi, HttpMethod.POST, null, WeatherResponse.class);
-        return response.getBody();
+    public String getWeather(String city, String userName) throws WeatherException {
+        try {
+            String weatherApi = appCache.getApiValue(WEATHER_API.toString());
+            weatherApi = weatherApi.replace(CITY,city).replace(API_KEY,apiKey);
+            ResponseEntity<WeatherResponse> response = restTemplate.exchange(weatherApi, HttpMethod.POST, null, WeatherResponse.class);
+            WeatherResponse weatherResponse = response.getBody();
+            String greeting = "";
+            if(weatherResponse != null ){
+                greeting = ", Weather of "+city+", feels like " + weatherResponse.getCurrent().getFeelslike();
+            }
+            return "Hi " + userName + greeting;
+        }catch (Exception e){
+            throw  new WeatherException("Some error occurred while fetching the weather Api details: ");
+        }
     }
 }

--- a/src/main/java/com/intelliguru/simplora/utils/constants/Constants.java
+++ b/src/main/java/com/intelliguru/simplora/utils/constants/Constants.java
@@ -1,0 +1,8 @@
+package com.intelliguru.simplora.utils.constants;
+
+public class Constants {
+    private Constants(){}
+    public static final String API_KEY = "<apiKey>";
+    public static final String CITY = "<city>";
+
+}

--- a/src/main/java/com/intelliguru/simplora/utils/constants/Keys.java
+++ b/src/main/java/com/intelliguru/simplora/utils/constants/Keys.java
@@ -1,0 +1,6 @@
+package com.intelliguru.simplora.utils.constants;
+
+public enum Keys {
+    WEATHER_API,
+    OTHER_API
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -21,3 +21,6 @@ server:
   port: 8080
   servlet:
     context-path: /journal
+weather:
+  api:
+    key: ${WEATHER_API_KEY}


### PR DESCRIPTION
In the previous commits, we have implemented the @PostConstruct functionality, which means if we want to load something only once during the beans initialization of the application, we can annotate the required method with @PostConstruct, which will load the value(let's if we have to load the db ad put that into cache[in-memory]).


Now, once the application started and something got changed in db then that value will not be reflected in cache, so we have created an endpoint which will reset the cache value without stopping or re-starting the application.